### PR TITLE
Create workaround so package works with scene delegate

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,9 +1,9 @@
 PODS:
   - Flutter (1.0.0)
-  - no_screenshot (0.3.2-beta.1):
+  - no_screenshot (0.3.2-beta.3):
     - Flutter
-    - ScreenProtectorKit (~> 1.3.1)
-  - ScreenProtectorKit (1.3.1)
+    - ScreenProtectorKit (~> 1.3.0)
+  - ScreenProtectorKit (1.3.0)
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
@@ -21,9 +21,9 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  no_screenshot: 908a71edc63ea17016f46537e0f420bc3856ce2c
+  no_screenshot: b67a579d0a0b66882af1d0751c6bc71b0f2b9d7c
   ScreenProtectorKit: 83a6281b02c7a5902ee6eac4f5045f674e902ae4
 
 PODFILE CHECKSUM: c4c93c5f6502fe2754f48404d3594bf779584011
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.16.2


### PR DESCRIPTION
Create a workaround so whenever state is changed (enable/disable screenshot functionality) we call the method to attach the window again if it is needed.